### PR TITLE
Make it easy to configure Varnish

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
-FROM        ubuntu:16.04
-MAINTAINER  Frank Lemanschik
+FROM ubuntu:16.04
+
+LABEL maintainer="technology@werkspot.com"
  
 ENV DEBIAN_FRONTEND noninteractive
 
-# Update apt sources
-#RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
+RUN apt-get -qq update \
+    && apt-get install -y varnish
 
-# Update the package repository
-RUN apt-get -qq update
+ENV LISTEN_ADDRESS "*:80"
 
-# Install base system
-RUN apt-get install -y varnish
-
-CMD ["varnishd", "-f", "/etc/varnish/default.vcl", "-s", "malloc,100M", "-a", "0.0.0.0:80", "-F"]
+CMD varnishd -f /etc/varnish/default.vcl -s malloc,100M -a $LISTEN_ADDRESS -F

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,12 @@ LABEL maintainer="technology@werkspot.com"
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq update \
-    && apt-get install -y varnish
+    && apt-get install -y varnish \
+    && rm -rf /var/lib/apt/lists/*
 
-ENV LISTEN_ADDRESS "*:80"
+ENV LISTEN_ADDRESS "*:8080" \
+    WORKING_DIRECTORY="/tmp/varnish"
 
-CMD varnishd -f /etc/varnish/default.vcl -s malloc,100M -a $LISTEN_ADDRESS -F
+USER nobody:nogroup
+
+CMD varnishd -f /etc/varnish/default.vcl -s malloc,100M -a $LISTEN_ADDRESS -n $WORKING_DIRECTORY -F


### PR DESCRIPTION
Make it easier to configure varnish via environment variables. Instead of overwriting the complete command/cmd.

As a bonus Varnish cannot also run as an unprivileged user. When the listen to address >= 1024 and the working directory is writable by the user. For instance `/tmp/varnish` (writable by anybody).