### PR TITLE
Put ENV on separate lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -qq update \
     && rm -rf /var/lib/apt/lists/*
 
 ENV LISTEN_ADDRESS "*:8080" \
-    WORKING_DIRECTORY="/tmp/varnish"
+ENV WORKING_DIRECTORY "/tmp/varnish"
 
 USER nobody:nogroup
 


### PR DESCRIPTION
    Put ENV on separate lines

    The ENV variables are currently mixed up.

    Using:
    `ENV X Y`
    and
    `ENV X=Y`
    on the same line

    https://stackoverflow.com/questions/45529121/dockerfile-setting-multiple-environment-variables-in-single-line

    Docker best practise tells to put all ENV variables on new lines