### PR TITLE
Put ENV on separate lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ LABEL maintainer="technology@werkspot.com"
  
 RUN apk add --no-cache varnish
 
-ENV LISTEN_ADDRESS ":8080" \
-    WORKING_DIRECTORY="/tmp/varnish"
+ENV LISTEN_ADDRESS ":8080"
+ENV WORKING_DIRECTORY "/tmp/varnish"
 
 USER nobody:nogroup
 


### PR DESCRIPTION
Put ENV on separate lines

The ENV variables are currently mixed up.

Using:
`ENV X Y`
and
`ENV X=Y`
on the same line

https://stackoverflow.com/questions/45529121/dockerfile-setting-multiple-environment-variables-in-single-line